### PR TITLE
Fixed the Error

### DIFF
--- a/resources/views/resume/elegant.blade.php
+++ b/resources/views/resume/elegant.blade.php
@@ -568,7 +568,7 @@
                                 <ul class="mt-1">
                                     @foreach ($hobbies as $hobby)
                                         {{-- This handles hobbies as simple strings or as objects with a 'name' key --}}
-                                        <li>{{ $hobby['name'] ?? $hobby }}</li>
+                                        <li>{{ is_array($hobby) ? ($hobby['name'] ?? '') : $hobby }}</li>
                                     @endforeach
                                 </ul>
                             </div>


### PR DESCRIPTION
• Issue Location: Line 571 in the hobbies section of elegant.blade.php • Problem: Code attempted to output {{ ['name'] ??  }}
  – This caused htmlspecialchars() to receive an array instead of a string when  was an array

Fix Applied:
• Updated logic to: {{ is_array() ? (['name'] ?? '') :  }} • Ensures output is always a string:
  – If  is an array, extract 'name' or default to empty string
  – If  is already a string, use it directly

Outcome:
• Resume PDF generation should now work without triggering the htmlspecialchars() error • Feedback has been submitted